### PR TITLE
Avoid using LD_PRELOAD by a child process

### DIFF
--- a/wcwidth-icons.c
+++ b/wcwidth-icons.c
@@ -46,3 +46,13 @@ wcswidth (const wchar_t *s, size_t n)
 
   return result;
 }
+
+/*
+ * Avoid using LD_PRELOAD by a child process
+ */
+int  __attribute__((constructor))
+main_init(void)
+{
+  unsetenv("LD_PRELOAD");
+  return 0;
+}


### PR DESCRIPTION
I can't reproduce anymore, but sometimes before on Nixos I had a problem: I can't run any other application in urxvt after switching to the new configuration (for example, can't run "awk", as far as I remember the error was related to libc).
I think it's because `LD_PRELOAD` was used by child process. After this change I didn't see this problem anymore. For me no sense to let child process use `LD_PRELOAD` env var. 
If you think it makes sense to unset this, you can merge.  But this solution is pretty dirty, theoretically you can have multiple files in `LD_PRELOAD` separated by ":" (or whitespace?), and ideally good to split and remove wcwidth-icons item only. 
